### PR TITLE
Fix page reloading

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -116,6 +116,9 @@ class Router extends Component {
         else {
             this._lastRenderedRoute = currentRoute;
 
+            // currentRoute must be rendered as an array; because, exiting and incoming is rendered as an array.
+            // if currentRoute is not rendered as an array, an bug happens where the exiting screen is reloaded,
+            // calling the constructor again. 
             if (Root) {
                 return <Root router={this.getRouterStrategy()} url={this.state.url}>{[currentRoute]}</Root>;
             }

--- a/src/Router.js
+++ b/src/Router.js
@@ -117,10 +117,10 @@ class Router extends Component {
             this._lastRenderedRoute = currentRoute;
 
             if (Root) {
-                return <Root router={this.getRouterStrategy()} url={this.state.url}>{currentRoute}</Root>;
+                return <Root router={this.getRouterStrategy()} url={this.state.url}>{[currentRoute]}</Root>;
             }
             else {
-                return currentRoute;
+                return [currentRoute];
             }
         }
     }

--- a/src/Router.js
+++ b/src/Router.js
@@ -117,7 +117,7 @@ class Router extends Component {
             this._lastRenderedRoute = currentRoute;
 
             // currentRoute must be rendered as an array; because, exiting and incoming is rendered as an array.
-            // if currentRoute is not rendered as an array, an bug happens where the exiting screen is reloaded,
+            // if currentRoute is not rendered as an array, a bug happens where the exiting screen is reloaded 
             // calling the constructor again. 
             if (Root) {
                 return <Root router={this.getRouterStrategy()} url={this.state.url}>{[currentRoute]}</Root>;


### PR DESCRIPTION
The Router has 2 blocks for rendering, 1 for transitions and 1 for no transitions.
The block without transitions renders a single component while the block with transitions renders and array of components.

Apparently switching from rendering a single component to rendering an array of components causes a bug where the exiting screen's constructor is called again. 

By just rendering an array of components all of the time the bug can be avoided.