### PR TITLE
Urlparse emptystring slash

### DIFF
--- a/spec/URLParser.spec.js
+++ b/spec/URLParser.spec.js
@@ -53,6 +53,14 @@ describe('URLParser', () => {
             expect(parser.parse('/login')).toEqual({});
         });
 
+        it('empty string', () => {
+            expect(parser.parse('')).toBe(null);
+        });
+
+        it('/', () => {
+            expect(parser.parse('/')).toBe(null);
+        });
+
         it('/test123', () => {
             expect(parser.parse('/test123')).toBe(null);
         });
@@ -71,6 +79,14 @@ describe('URLParser', () => {
             });
         });
 
+        it('empty string', () => {
+            expect(parser.parse('')).toBe(null);
+        });
+
+        it('/', () => {
+            expect(parser.parse('/')).toBe(null);
+        });
+
         it('/fname', () => {
             expect(parser.parse('/fname')).toBe(null);
         });
@@ -86,6 +102,14 @@ describe('URLParser', () => {
 
     describe('/name/:fname/:lname', () => {
         let parser = new URLParser('/name/:fname/:lname');
+
+        it('empty string', () => {
+            expect(parser.parse('')).toBe(null);
+        });
+
+        it('/', () => {
+            expect(parser.parse('/')).toBe(null);
+        });
 
         it('/name', () => {
             expect(parser.parse('/name')).toBe(null);

--- a/src/URLParser.js
+++ b/src/URLParser.js
@@ -14,7 +14,8 @@ export class URLParser {
         let parts = this._getParts(url);
         let patternParts = this._getParts(this._pattern);
 
-        if (!this._allowPartialMatch && parts.length !== patternParts.length) {
+        if ((!this._allowPartialMatch && parts.length !== patternParts.length) || url === '') {
+        // if (!this._allowPartialMatch && parts.length !== patternParts.length) {
             return null;
         }
 

--- a/src/URLParser.js
+++ b/src/URLParser.js
@@ -15,7 +15,6 @@ export class URLParser {
         let patternParts = this._getParts(this._pattern);
 
         if ((!this._allowPartialMatch && parts.length !== patternParts.length) || url === '') {
-        // if (!this._allowPartialMatch && parts.length !== patternParts.length) {
             return null;
         }
 


### PR DESCRIPTION
Passing in empty string or '/' causes the function return an empty object which is truthy. This causes the wrong route to be matched in RouteMatcher. 
URLParse.parse should return null instead of an empty object.